### PR TITLE
Fix config not being used

### DIFF
--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -25,7 +25,7 @@ class LuaLanguageServer {
       this
     );
     
-    nova.config.observe(
+    nova.workspace.config.observe(
       "luals.workspace.config-file",
       function (configPath) {
         this.configPath = configPath;
@@ -56,7 +56,7 @@ class LuaLanguageServer {
     };
     
     if (this.configPath) {
-      serverOptions[args] = ["--configfile", this.configPath];
+      serverOptions.args = [`--configpath ${this.configPath}`];
     }
     
     var clientOptions = {


### PR DESCRIPTION
Noticed while working on a project that the settings I had in my `.luarc.json` file were not being reflected by the warnings I was seeing. I looked into the log file generated by the langauge server and noticed that it was using the default configuration. So I added some logs in the extension to see if and what was being passed in, resulting in a few small changes to get it working again. 